### PR TITLE
Add template for NetBox Basis

### DIFF
--- a/qeneth
+++ b/qeneth
@@ -360,6 +360,7 @@ usage: ${0} <command> [<args>]
 
   ${0} console <node>
     Start a telnet session to the specified node's console.
+    To detach: use telnet Ctrl-] for a prompt, and 'quit' to exit.
 
   ${0} monitor <node>
     Start a telnet session to the specified node's monitor.

--- a/templates/inc/netbox-common.mustache
+++ b/templates/inc/netbox-common.mustache
@@ -1,4 +1,4 @@
-  -append "root=/dev/ram console=$con,115200 {{qn_append}}" \
+  -append "root=/dev/ram $append console=$con,115200 {{qn_append}}" \
   -device virtio-serial -device virtconsole,chardev=hvc0 -device virtconsole,chardev=hvc1 -device virtconsole,chardev=hvc2 \
     -display none -monitor telnet::{{qn_monitor}},server,nowait -gdb tcp::{{qn_kgdb}},server,nowait \
     -chardev socket,id=hvc0,host=localhost,port={{qn_console}},server,nowait,telnet \

--- a/templates/inc/netbox-common.mustache
+++ b/templates/inc/netbox-common.mustache
@@ -4,4 +4,6 @@
     -chardev socket,id=hvc0,host=localhost,port={{qn_console}},server,nowait,telnet \
     -chardev socket,id=hvc1,host=localhost,port={{qn_ugdb}},server,nowait,telnet \
     -chardev stdio,mux=on,id=hvc2 \
-  -drive if=virtio,file={{name}}.disk,format=raw
+  -drive if=virtio,file={{name}}.disk,format=raw \
+  -rtc base=utc,clock=host \
+  -watchdog i6300esb

--- a/templates/netbox-os-basis.mustache
+++ b/templates/netbox-os-basis.mustache
@@ -10,6 +10,9 @@ unsquashfs -f -d $imgdir $img boot/zImage boot/versatile-pb.dtb
 
 {{> inc/netbox-disk}}
 
+# Disable pulseaudio warning
+export QEMU_AUDIO_DRV=none
+
 exec qemu-system-arm -M versatilepb -dtb $imgdir/boot/versatile-pb.dtb \
   -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}128M{{/qn_mem}} \
 {{> inc/qemu-links}}

--- a/templates/netbox-os-basis.mustache
+++ b/templates/netbox-os-basis.mustache
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+con=hvc0
+tty -s && con=hvc2
+
+img={{#qn_image}}{{qn_image}}{{/qn_image}}{{^qn_image}}netbox-os-basis.img{{/qn_image}}
+imgdir=./.$(realpath $img | sed -e s:/:-:g)
+append="ramdisk_size=$((($(find -L "${img}" -printf %s)+1023) >> 10))"
+unsquashfs -f -d $imgdir $img boot/zImage boot/versatile-pb.dtb
+
+{{> inc/netbox-disk}}
+
+exec qemu-system-arm -M versatilepb -dtb $imgdir/boot/versatile-pb.dtb \
+  -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}128M{{/qn_mem}} \
+{{> inc/qemu-links}}
+  -kernel $imgdir/boot/zImage -initrd $img \
+{{> inc/netbox-common}}

--- a/templates/netbox-os-zero.mustache
+++ b/templates/netbox-os-zero.mustache
@@ -10,6 +10,9 @@ unsquashfs -f -d $imgdir $img boot/bzImage
 
 {{> inc/netbox-disk}}
 
+# Disable pulseaudio warning
+export QEMU_AUDIO_DRV=none
+
 exec qemu-system-x86_64 -M pc,accel=kvm:tcg -cpu max \
   -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}128M{{/qn_mem}} \
 {{> inc/qemu-links}}


### PR DESCRIPTION
This patch set adds support for running qeneth with NetBox Basis targets. Notice the additional `$append` to the common include, for appending 'ramdisk_size`.

Also, mention in help text how to disconnect from a qeneth console.
