### PR TITLE
infix: Add support for USB ports

### DIFF
--- a/templates/inc/infix-usb.mustache
+++ b/templates/inc/infix-usb.mustache
@@ -1,0 +1,9 @@
+usb_cmd=""
+
+if [ -n "{{qn_usb}}" ]; then
+   if ! [ -f {{qn_usb}} ]; then
+       dd if=/dev/zero of={{qn_usb}} bs=8M count=1 >/dev/null 2>&1
+       mkfs.vfat {{qn_usb}}  >/dev/null 2>&1
+   fi
+   usb_cmd=" -drive if=none,id=usbstick,format=raw,file={{qn_usb}} -usb -device usb-ehci,id=ehci -device usb-storage,bus=ehci.0,drive=usbstick "
+fi

--- a/templates/infix-x86_64.mustache
+++ b/templates/infix-x86_64.mustache
@@ -10,9 +10,11 @@ imgdir=./.$(realpath $img | sed -e s:/:-:g)
 unsquashfs -n -f -d $imgdir $img boot/bzImage >/dev/null
 
 {{> inc/infix-disk}}
+{{> inc/infix-usb}}
 
 exec qemu-system-x86_64 -M pc,accel=kvm:tcg -cpu max \
   -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}256M{{/qn_mem}} \
 {{> inc/qemu-links}}
   -kernel $imgdir/boot/bzImage -initrd $img \
+   $usb_cmd \
 {{> inc/infix-common}}


### PR DESCRIPTION
It is opt-in from topology, specify a disk-file (qn_usb) to use the feature.

dut1 [
    label="{ <eth0> eth0 | <eth1> eth1 | <eth2> eth2 } | dut1 | { <eth3> eth3 | <eth4> eth4 | <eth5> eth5 | <eth6> eth6 | <eth7> eth7}",
    pos="10,18!",
    kind="infix",
    qn_console=9001,
    qn_mem="384M",
    qn_usb="dut1.usb"
];