### PR TITLE
Use root=/dev/ram0 for infix and netbox

### DIFF
--- a/templates/inc/infix-common.mustache
+++ b/templates/inc/infix-common.mustache
@@ -1,4 +1,4 @@
-  -append "root=/dev/ram ramdisk_size=$imgsz console=$con,115200 $append {{qn_append}}"		\
+  -append "root=/dev/ram0 ramdisk_size=$imgsz console=$con,115200 $append {{qn_append}}"		\
   -drive file={{name}}.disk,if=virtio,format=raw,bus=0,unit=1 -display none			\
   -fw_cfg name=opt/hostname,string={{name}}							\
   -rtc base=utc,clock=vm -rtc clock=host -device i6300esb -device virtio-serial			\

--- a/templates/inc/netbox-common.mustache
+++ b/templates/inc/netbox-common.mustache
@@ -1,4 +1,4 @@
-  -append "root=/dev/ram console=$con,115200 $append {{qn_append}}"							   \
+  -append "root=/dev/ram0 console=$con,115200 $append {{qn_append}}"							   \
   -device virtio-serial -device virtconsole,chardev=hvc0 -device virtconsole,chardev=hvc1 -device virtconsole,chardev=hvc2 \
     -display none -monitor telnet::{{qn_monitor}},server=on,wait=off -gdb tcp::{{qn_kgdb}},server=on,wait=off 		   \
     -chardev socket,id=hvc0,host=localhost,port={{qn_console}},server=on,wait=off,telnet=on 				   \


### PR DESCRIPTION
This since this is an actual file and that makes latest rauc (https://github.com/rauc/rauc) work.

In infix we already use /dev/ram0 when start quemu instances.