### PR TITLE
infix: Add support for using BIOS, not only raw kernel images

### DIFF
--- a/templates/inc/infix-common.mustache
+++ b/templates/inc/infix-common.mustache
@@ -1,6 +1,4 @@
-  -append "root=/dev/ram0 ramdisk_size=$imgsz console=$con,115200 $append {{qn_append}}"		\
-  -drive file={{name}}.disk,if=virtio,format=raw,bus=0,unit=1 -display none			\
-  -fw_cfg name=opt/hostname,string={{name}}							\
+  -fw_cfg name=opt/hostname,string={{name}} -display none					\
   -rtc base=utc,clock=vm -rtc clock=host -device i6300esb -device virtio-serial			\
   -monitor telnet::{{qn_monitor}},server=on,wait=off -gdb tcp::{{qn_kgdb}},server=on,wait=off	\
   -device virtconsole,chardev=hvc0								\

--- a/templates/infix-bios-x86_64.mustache
+++ b/templates/infix-bios-x86_64.mustache
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+con=hvc0
+tty -s && con=hvc2
+
+img={{#qn_image}}{{qn_image}}{{/qn_image}}{{^qn_image}}infix-x86_64-disk.img{{/qn_image}}
+bios={{#qn_bios}}{{qn_bios}}{{/qn_bios}}{{^qn_bios}}OVMF.fd{{/qn_bios}}
+{{> inc/infix-usb}}
+
+origimg=$(realpath $img)
+qemu-img create -f qcow2 -o backing_file=$origimg -F raw {{name}}.qcow2
+
+exec qemu-system-x86_64 -M pc,accel=kvm:tcg -cpu max \
+  -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}256M{{/qn_mem}} \
+{{> inc/qemu-links}}
+    -bios $bios \
+    -drive file={{name}}.qcow2,if=virtio,format=qcow2,bus=0,unit=1 \
+    $usb_cmd \
+{{> inc/infix-common}}

--- a/templates/infix-kernel-x86_64.mustache
+++ b/templates/infix-kernel-x86_64.mustache
@@ -9,12 +9,15 @@ imgdir=./.$(realpath $img | sed -e s:/:-:g)
 
 unsquashfs -n -f -d $imgdir $img boot/bzImage >/dev/null
 
+
 {{> inc/infix-disk}}
 {{> inc/infix-usb}}
 
 exec qemu-system-x86_64 -M pc,accel=kvm:tcg -cpu max \
   -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}256M{{/qn_mem}} \
 {{> inc/qemu-links}}
-  -kernel $imgdir/boot/bzImage -initrd $img \
-   $usb_cmd \
+    -kernel $imgdir/boot/bzImage -initrd $img \
+    -drive file={{name}}.disk,if=virtio,format=raw,bus=0,unit=1  \
+    -append "root=/dev/ram0 ramdisk_size=$imgsz console=$con,115200 {{qn_append}}" \
+    $usb_cmd \
 {{> inc/infix-common}}


### PR DESCRIPTION
* Rename original template to infix-kernel-x86_64
* Introduce a new template infix-bios-x86_64 