### PR TITLE
Drop developer debug printf()

### DIFF
--- a/qeneth
+++ b/qeneth
@@ -244,7 +244,6 @@ genyaml()
 		for (attr = 3; attr < NF; attr += 2) {
 			val = attr + 1;
 
-			printf("%s = %s\n", $attr, $val);
 			if ($attr == "qn_mac")
 				seen_mac = "true";
 


### PR DESCRIPTION
The previous PR contained a developer debug printf() that I forgot to remove.