### PR TITLE
Sync Infix BIOS and kernel templates

### DIFF
--- a/templates/infix-bios-x86_64.mustache
+++ b/templates/infix-bios-x86_64.mustache
@@ -10,9 +10,15 @@ bios={{#qn_bios}}{{qn_bios}}{{/qn_bios}}{{^qn_bios}}OVMF.fd{{/qn_bios}}
 origimg=$(realpath $img)
 qemu-img create -f qcow2 -o backing_file=$origimg -F raw {{name}}.qcow2
 
+truncate -s 0 $imgdir/{{name}}.mactab
+{{#links}}
+echo "{{qn_name}}	{{qn_mac}}" >>$imgdir/{{name}}.mactab
+{{/links}}
+
 exec qemu-system-x86_64 -M pc,accel=kvm:tcg -cpu max \
   -m {{#qn_mem}}{{qn_mem}}{{/qn_mem}}{{^qn_mem}}256M{{/qn_mem}} \
 {{> inc/qemu-links}}
+    -fw_cfg name=opt/mactab,file=$imgdir/{{name}}.mactab \
     -bios $bios \
     -drive file={{name}}.qcow2,if=virtio,format=qcow2,bus=0,unit=1 \
     $usb_cmd \


### PR DESCRIPTION
Add missing dutN.mactab to BIOS template that got lost during merge conflict resolution prior to last PR.
